### PR TITLE
MANIFEST.in: Explicit rules for all files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,10 @@
 include setup_boilerplate.py
 include *requirements.txt
+include pyproject.toml
 include LICENSE
 include NOTICE
 include ./*/py.typed
+recursive-include test *.py
+exclude appveyor.yml
+recursive-exclude .build *
+exclude .build


### PR DESCRIPTION
Allow `check-manifest -u` to identify any missing files.

Fixes https://github.com/mbdevpl/version-query/issues/4