### PR TITLE
improve Python package metadata finding when running outside of git repositories

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,6 +51,8 @@ jobs:
       - run: python -m coverage run --append --branch --source . -m unittest -v test.test_version
         env:
           LOGGING_LEVEL: critical
+      - run: python -m pip install -e .
+      - run: python -m coverage run --append --branch --source . -m pip install --no-build-isolation --no-binary ebrains-drive ebrains-drive==0.6.0
       - run: python -m coverage report --show-missing
       - run: codecov
   publish:

--- a/version_query/py_query.py
+++ b/version_query/py_query.py
@@ -32,7 +32,7 @@ def query_package_folder(path: pathlib.Path, search_parent_directories: bool = F
     paths = [path]
     if search_parent_directories:
         paths += path.parents
-    metadata_json_paths, pkg_info_paths = None, None
+    global_metadata_json_paths, global_pkg_info_paths = [], []
     for pth in paths:
         metadata_json_paths = list(pth.parent.glob(f'{pth.name}*.dist-info/metadata.json'))
         pkg_info_paths = list(pth.parent.glob(f'{pth.name}*.egg-info/PKG-INFO'))
@@ -41,4 +41,13 @@ def query_package_folder(path: pathlib.Path, search_parent_directories: bool = F
             return query_metadata_json(metadata_json_paths[0])
         if not metadata_json_paths and len(pkg_info_paths) == 1:
             return query_pkg_info(pkg_info_paths[0])
-    raise ValueError(paths, metadata_json_paths, pkg_info_paths)
+        _LOG.debug(
+            'in %s found %i JSON metadata: %s and %i PKG-INFO metadata: %s'
+            ' - unable to infer package metadata, continuing search',
+            pth, len(metadata_json_paths), metadata_json_paths, len(pkg_info_paths), pkg_info_paths)
+        global_metadata_json_paths.extend(metadata_json_paths)
+        global_pkg_info_paths.extend(pkg_info_paths)
+    raise ValueError(
+        f'unable to infer package metadata from the following paths {paths} '
+        f'- found {len(global_metadata_json_paths)} JSON metadata: {global_metadata_json_paths}'
+        f' and {len(global_pkg_info_paths)} PKG-INFO metadata: {global_pkg_info_paths}')

--- a/version_query/query.py
+++ b/version_query/query.py
@@ -19,7 +19,7 @@ def _caller_folder(stack_level: int = 1) -> pathlib.Path:
     caller_path = frame_info[1]  # frame_info.filename
 
     here = pathlib.Path(caller_path).absolute().resolve()
-    assert here.is_file(), here
+    assert here.is_file() or here.name == '<string>', here
     here = here.parent
     assert here.is_dir(), here
     _LOG.debug('found directory "%s"', here)


### PR DESCRIPTION
To test interactively, in `docker run -it python:3.13 bash` run:

```
pip install setuptools
pip install git+https://github.com/mbdevpl/version-query.git@feature/improve-metadata-finding
pip install --no-build-isolation --no-clean --no-binary ebrains-drive ebrains-drive==0.6.0
```

or

```
pip install setuptools wheel
pip install git+https://github.com/mbdevpl/version-query.git@feature/improve-metadata-finding
pip install --no-build-isolation --no-clean --no-binary ebrains-drive ebrains-drive==0.6.0
```

related: HumanBrainProject/ebrains-storage#33